### PR TITLE
Remove "pepe" "discord" and "blob" emoji from emojiful glyph picker

### DIFF
--- a/config/emojiful.json
+++ b/config/emojiful.json
@@ -1,0 +1,12 @@
+{
+  "renderEmoji": true,
+  "emojiSelector": true,
+  "emojiAutocomplete": true,
+  "gifEmojis": true,
+  "emojiReplacement": true,
+  "enableLoadTwemoji": true,
+  "loadCustom": false,
+  "loadDatapack": true,
+  "profanityFilter": false,
+  "profanityFilterReplacement": ":swear:"
+}

--- a/config/emojiful.json
+++ b/config/emojiful.json
@@ -6,7 +6,7 @@
   "emojiReplacement": true,
   "enableLoadTwemoji": true,
   "loadCustom": false,
-  "loadDatapack": true,
+  "loadDatapack": false,
   "profanityFilter": false,
   "profanityFilterReplacement": ":swear:"
 }

--- a/index.toml
+++ b/index.toml
@@ -10,7 +10,7 @@ hash = "7849b2952a69e67303d1afeef3a5504f3bf6ee008ebce28248b1af7d3a33750b"
 
 [[files]]
 file = "config/emojiful.json"
-hash = "6227f5dccae6d7970eea294faf12d60595a7edd246dd042a2444e2480a78a829"
+hash = "93ed3e7df540ee71fe099bbafe36e10d51adb47f0dd39236e78371cba13f2b40"
 
 [[files]]
 file = "config/fwaystones/config.json5"

--- a/index.toml
+++ b/index.toml
@@ -9,6 +9,10 @@ file = "config/defaultoptions/keybindings.txt"
 hash = "7849b2952a69e67303d1afeef3a5504f3bf6ee008ebce28248b1af7d3a33750b"
 
 [[files]]
+file = "config/emojiful.json"
+hash = "6227f5dccae6d7970eea294faf12d60595a7edd246dd042a2444e2480a78a829"
+
+[[files]]
 file = "config/fwaystones/config.json5"
 hash = "f3eab60089ca26ff4a5214126f6435965cd756511380ba7953ca992f34b32a4f"
 

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "9f914f0610a28a5327a871cf71a8cc2be81056dfb8f20d2eefddb85e9445884f"
+hash = "a68921524f77d4ef6333a6792fa6ecfa8fccadd3bf04a22d6039c2181c07d00a"
 
 [versions]
 fabric = "0.15.6"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f798e4bf39b4c401291dd068bd0766d24e9c3b7c87bebd9f17d63ffb674139c4"
+hash = "9f914f0610a28a5327a871cf71a8cc2be81056dfb8f20d2eefddb85e9445884f"
 
 [versions]
 fabric = "0.15.6"


### PR DESCRIPTION
`loadDatapack` will need to be re-enabled if we ever add custom emoji, and if we really care about edge case datapack containing `test.json` and `comfy.json` (mod author did not remove tests) then will have to figure out a way to granularly disable datapacks.